### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/cubicle-jockey/cj_ascii/security/code-scanning/1](https://github.com/cubicle-jockey/cj_ascii/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions to `contents: read`, which is sufficient for the operations performed in this workflow (building and testing the Rust project). This change ensures that the workflow does not inadvertently inherit broader permissions from the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
